### PR TITLE
Delete the link not existed

### DIFF
--- a/source/event/__index.md
+++ b/source/event/__index.md
@@ -16,9 +16,7 @@ those events which have been approved to use Apache Marks under the
 For a complete list of events see our [calendar](calendar.html).
 
 In addition to Official Apache Events, there are a wide range of other
-events which feature Apache projects and technologies. A crowd-source
-list of these is maintained as a [Lanyrd Guide][2], and we encourage
-people to help list related events here.
+events which feature Apache projects and technologies.
 
 <script src="/js/jquery.js"></script>
 <script src="/js/events-calendar.js"></script>


### PR DESCRIPTION
It seems that the Lanyrd Guide Calendar is not maintained anymore, so just delete it.