### PR TITLE
Use UTC to show times

### DIFF
--- a/source/event/calendar.md
+++ b/source/event/calendar.md
@@ -5,7 +5,7 @@ title: Apache Conferences Calendar
 This Calendar is maintained by the [Apache Conferences Committee][1] (ConCom). It's used to list official Apache events, and 
 those events which have been approved to use Apache Marks under the [Third Party Event Branding Policy][2].
 
-<iframe src="https://www.google.com/calendar/embed?src=nerseigospses068jd57bk5ar8%40group.calendar.google.com&ctz=America/New_York"
+<iframe src="https://www.google.com/calendar/embed?src=nerseigospses068jd57bk5ar8%40group.calendar.google.com&ctz=UTC"
 style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
 This Calendar is also available as an [iCal feed][3]


### PR DESCRIPTION
It does not make sense to show global events in a local time zone.