### PR TITLE
Simplify local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ To generate the static website, execute `hugo` to generate the website under tar
 During development, it may be useful to run an incremental build. For this to work, execute `hugo server -D` to
 continuously (re)generate and serve the website on `localhost:1313`.
 
+Use the hostname `events-site.local` to avoid https redirection by the .htaccess file
+
 # How-To add an ApacheCon event promotion to your project site
 
 All PMCs are asked to help promote ApacheCon and other major Apache

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -17,6 +17,8 @@ RewriteEngine On
 
 # Redirect to https
 RewriteCond %{HTTPS} !=on
+# For local testing, use the hostname events-site.local to avoid https redirection
+RewriteCond %{HTTP_HOST} !=events-site.local
 RewriteRule ^/?(.*) https://events.apache.org/$1 [R,L]
 
 


### PR DESCRIPTION
Add a rule to bypass redirect to https site if the hostname is events-site.local