### PR TITLE
Add proposed event funding application forms (not linked)

### DIFF
--- a/source/events/apply/_index.md
+++ b/source/events/apply/_index.md
@@ -1,0 +1,52 @@
+---
+title: "Apply for Event Funding (PROPOSED)"
+url: /apply/index.html
+---
+
+{{< alert color="warning" >}}
+**This program is not yet active.** No applications are being accepted.
+The mailing list does not exist yet. This page describes the proposed
+process for discussion purposes. See
+[dev@community.apache.org](https://lists.apache.org/list.html?dev@community.apache.org)
+for the ongoing discussion.
+{{< /alert >}}
+
+# Apply for Event Funding
+
+ComDev proposes to fund small community events and speaker travel for
+ASF contributors who lack corporate backing.
+
+## Programs
+
+| Program | What it covers | Max |
+|---------|---------------|-----|
+| [Speaker Travel Grants](speaker-travel/) | Economy travel + hotel for conference speakers | $3,000 |
+| [Evening Meetups](meetup/) | Food + supplies for a community gathering | $400 |
+| [Contributor Sprints](sprint/) | Full-day venue + catering for focused coding | $1,800 |
+| [Single-Day Summits](summit/) | Full-day event with catering and AV | $6,000 |
+| [Event Materials](materials/) | Stickers, badges, signage, supplies | $200 |
+
+## Who can apply
+
+- Individual contributors whose employers don't cover travel or events
+- ALC chapters hosting regular community events
+- Communities growing in regions without big-tech presence
+
+**Not eligible:** Projects with multiple vendor sponsors already funding
+their events; speakers whose employers cover travel; events with
+existing corporate sponsorship covering costs.
+
+**Principle: ASF resources go where the market won't.**
+
+## How to apply (once active)
+
+1. Choose the program that fits your request
+2. Copy the application form from the relevant page below
+3. Fill it out in your email client
+4. Send to the events grants mailing list (address TBD)
+5. A committee member acknowledges within 5 business days
+6. Decision communicated per the timelines on each program page
+
+All applications go to a private, moderated mailing list. You don't
+need to be subscribed to send -- messages from non-subscribers are
+held briefly for moderator approval and then processed normally.

--- a/source/events/apply/materials.md
+++ b/source/events/apply/materials.md
@@ -1,0 +1,75 @@
+---
+title: "Event Materials Reimbursement (PROPOSED)"
+---
+
+{{< alert color="warning" >}}
+**Not yet active.** No applications are being accepted at this time.
+{{< /alert >}}
+
+# Event Materials Reimbursement
+
+Up to $200 per event for locally-purchased materials.
+**Pre-approval required** before purchase.
+
+## What's covered
+
+- Stickers (ASF logo, project logos)
+- Name badges and lanyards
+- Signage (directional signs, welcome banners)
+- Power strips and extension cords
+- Markers, sticky notes, whiteboard supplies
+- Printed handouts
+
+## Not covered
+
+- T-shirts, food/drinks, AV purchases, company-promotional items
+
+## Process
+
+1. Send pre-approval request (form below) **before** purchasing
+2. Committee approves on-list (48hrs)
+3. Purchase materials
+4. Reply to approval thread with receipt photos
+5. Reimbursement within 30 days
+
+## Pre-Approval Form
+
+**Subject:** `[MATERIALS] Pre-approval -- Event Name, Date`
+
+{{< copyblock id="materials-form" >}}
+MATERIALS PRE-APPROVAL REQUEST
+===============================
+
+1. EVENT
+   Event name:
+   Event date:
+   Event type: [Meetup / Sprint / Summit]
+   Associated funding request (if any): [link to approval thread]
+
+2. MATERIALS NEEDED
+   Item                          | Estimated Cost
+   ------------------------------|---------------
+   [e.g., 100 stickers]          | $[X]
+   [e.g., 20 name badges]        | $[X]
+   [e.g., directional signage]   | $[X]
+   [e.g., 2 power strips]        | $[X]
+                                  |
+   TOTAL REQUESTED:              | $[X] (max $200)
+
+3. PURCHASE PLAN
+   Where will you buy these? (local print shop, office supply
+   store, online vendor, etc.):
+
+4. ORGANIZER
+   Name:
+   Apache ID (if any):
+   Email:
+{{< /copyblock >}}
+
+## After purchase
+
+Reply to your pre-approval thread with subject:
+
+`[MATERIALS] Receipts -- Event Name, Date -- $Amount`
+
+Attach receipt photos or PDFs.

--- a/source/events/apply/meetup.md
+++ b/source/events/apply/meetup.md
@@ -1,0 +1,67 @@
+---
+title: "Meetup Funding (PROPOSED)"
+---
+
+{{< alert color="warning" >}}
+**Not yet active.** No applications are being accepted at this time.
+{{< /alert >}}
+
+# Evening Meetup Funding
+
+Up to $400 to cover food and supplies for a community gathering.
+Venues are expected to be donated. Priority to ALC chapters.
+
+## Eligibility
+
+- ALC chapter organizers
+- Apache project committers/contributors organizing a local meetup
+- Anyone with a donated venue and a plan to gather Apache enthusiasts
+
+## What's covered
+
+- Pizza / catering for ~20 people
+- Soft drinks and water
+- Paper plates, napkins, cups, basic supplies
+
+## Application Form
+
+**Subject:** `[MEETUP] Project/ALC -- City, Date`
+
+{{< copyblock id="meetup-form" >}}
+MEETUP FUNDING REQUEST
+======================
+
+1. ORGANIZER
+   Name:
+   Apache ID (if any):
+   ALC Chapter (if applicable):
+   Email:
+
+2. EVENT DETAILS
+   Date:
+   Time:
+   Venue (name + address):
+   Venue cost: $0 (donated) / $[amount if not free]
+   Expected attendance:
+   Event page URL (if exists):
+
+3. PROJECT/TOPIC
+   Which Apache project(s) or topic area?
+   Brief description of planned activity (talks, demos, social):
+
+4. BUDGET
+   Food (pizza/catering, describe): $
+   Drinks: $
+   Supplies (plates, napkins, etc.): $
+   Other (specify): $
+   TOTAL REQUESTED (max $400): $
+
+5. SPONSORSHIP
+   Are you seeking local sponsors? [Yes/No]:
+   If yes, what is the sponsor covering?
+{{< /copyblock >}}
+
+## After the event
+
+Post a brief report to dev@community.apache.org and submit receipts
+for reimbursement.

--- a/source/events/apply/speaker-travel.md
+++ b/source/events/apply/speaker-travel.md
@@ -1,0 +1,106 @@
+---
+title: "Speaker Travel Grants (PROPOSED)"
+---
+
+{{< alert color="warning" >}}
+**Not yet active.** No applications are being accepted at this time.
+{{< /alert >}}
+
+# Speaker Travel Grants
+
+Up to $3,000 for ASF contributors with accepted talks at non-Apache
+conferences who lack employer funding for travel.
+
+## Eligibility
+
+- Talk **accepted** (not just submitted) at a non-Apache conference
+- Talk covers an Apache project or The Apache Way
+- Your employer does not provide sufficient travel funding
+- Same-continent travel preferred; inter-continental requires
+  committee override
+
+## What's covered
+
+- Economy class airfare
+- Hotel (mid-range, within 3 miles of venue, up to 3 nights)
+- Conference registration (if not waived for speakers)
+- Ground transport to/from airport
+
+## Important
+
+- Maximum: $3,000
+- We verify cost estimates against current economy fares and
+  reasonable hotels near the venue. Inflated requests are rejected.
+- Reimbursement-based: you pay upfront, submit receipts afterward
+- One grant per person per fiscal year
+- Must provide at least one deliverable within 30 days (blog post,
+  slides, video, trip report, or social media coverage)
+
+## Application Form
+
+Once active, copy the form below into an email to the events grants
+list (address TBD).
+
+**Subject:** `[TRAVEL GRANT] Your Name -- Conference Name, City, Date`
+
+{{< copyblock id="travel-form" >}}
+SPEAKER TRAVEL GRANT APPLICATION
+=================================
+
+1. ABOUT YOU
+   Name:
+   Apache ID (if any):
+   Email:
+   Employer (or "independent/unemployed/student"):
+   Does your employer provide conference travel funding? [Yes/No/Partial]:
+   If partial, what does your employer cover?
+
+2. CONFERENCE DETAILS
+   Conference name:
+   Conference URL:
+   Conference dates:
+   Conference location (city, country):
+   Expected attendance (approximate):
+   Is this an established conference (>2 years running)? [Yes/No]:
+
+3. YOUR TALK
+   Talk title:
+   Talk abstract (2-3 sentences):
+   Has the talk been accepted? [Yes/Submitted/Invited]:
+   If accepted, link to acceptance or program page:
+   Which Apache project(s) does the talk cover?
+
+4. TRAVEL DETAILS
+   Traveling from (city, country):
+   Estimated airfare (economy class):
+   Estimated hotel (# nights x nightly rate):
+   Conference registration fee (if any):
+   Other costs (ground transport, visa, etc.):
+   TOTAL ESTIMATED COST:
+
+5. AMOUNT REQUESTED
+   Amount requested from ComDev (up to $3,000):
+   Are you receiving partial funding from another source? [Yes/No]:
+   If yes, how much and from whom?
+
+6. EXPECTED DELIVERABLES
+   (Check all you commit to providing after the event)
+   [ ] Blog post on blogs.apache.org or personal blog
+   [ ] Slides published publicly (SpeakerDeck, GitHub, etc.)
+   [ ] Video recording shared (if conference records)
+   [ ] Trip report email to dev@community.apache.org
+   [ ] Social media post(s) about the talk/event
+
+7. ANYTHING ELSE
+   (Optional: context on why this grant matters to you or your
+   community, prior speaking experience, etc.)
+{{< /copyblock >}}
+
+## What happens next
+
+1. Committee acknowledges receipt (5 business days)
+2. Independent cost estimate produced
+3. Two committee members score your application
+4. Decision communicated (15 business days)
+5. If approved: attend, deliver, submit receipts
+6. Reimbursement within 30 days of complete receipts

--- a/source/events/apply/sprint.md
+++ b/source/events/apply/sprint.md
@@ -1,0 +1,68 @@
+---
+title: "Contributor Sprint Funding (PROPOSED)"
+---
+
+{{< alert color="warning" >}}
+**Not yet active.** No applications are being accepted at this time.
+{{< /alert >}}
+
+# Contributor Sprint Funding
+
+Up to $1,800 for a full-day focused coding event (~15 people).
+
+## Eligibility
+
+- Apache project committers organizing a sprint
+- Must have experienced reviewers confirmed to attend
+
+## What's covered
+
+- Venue rental (if not donated)
+- Lunch, snacks, coffee
+- Power strips, signage, supplies
+
+## Application Form
+
+**Subject:** `[SPRINT] Project -- City, Date`
+
+{{< copyblock id="sprint-form" >}}
+SPRINT FUNDING REQUEST
+======================
+
+1. ORGANIZER
+   Name:
+   Apache ID:
+   Role on project (committer/PMC/etc.):
+   Email:
+
+2. EVENT DETAILS
+   Date:
+   Start/end time:
+   Venue (name + address):
+   Venue cost: $0 (donated) / $[amount]
+   Expected attendance:
+   Event page URL (if exists):
+
+3. PROJECT
+   Apache project:
+   What will participants work on? (curated issues, docs, release
+   prep, etc.):
+   Link to curated issue list (if available):
+   How many experienced reviewers will be present to review PRs?
+
+4. BUDGET
+   Venue (if not donated): $
+   Catering (lunch + snacks + coffee): $
+   Supplies (power strips, signage, badges): $
+   Other (specify): $
+   TOTAL REQUESTED (max $1,800): $
+
+5. OUTREACH PLAN
+   How will you promote this to potential participants?
+   Will newcomers be explicitly welcomed and paired with mentors?
+{{< /copyblock >}}
+
+## After the event
+
+Post a report to dev@community.apache.org (attendance, PRs, outcomes)
+and submit receipts for reimbursement.

--- a/source/events/apply/summit.md
+++ b/source/events/apply/summit.md
@@ -1,0 +1,90 @@
+---
+title: "Single-Day Summit Funding (PROPOSED)"
+---
+
+{{< alert color="warning" >}}
+**Not yet active.** No applications are being accepted at this time.
+{{< /alert >}}
+
+# Single-Day Project Summit Funding
+
+Up to $6,000 for a full-day project summit (~40 people).
+
+## Eligibility
+
+- Apache project PMC members
+- **Requires PMC approval:** link to a lists.apache.org thread showing
+  your project PMC discussed and approved this request
+
+## What's covered
+
+- Venue rental
+- Full-day catering (breakfast, lunch, breaks)
+- AV equipment rental
+- Signage and printed materials
+
+## Not covered
+
+- Multi-day events (require external sponsorship, fall under VP Conferences)
+- Events that are essentially vendor product launches
+- Speaker travel (apply separately under Speaker Travel Grants)
+
+## Application Form
+
+**Subject:** `[SUMMIT] Project -- City, Date`
+
+{{< copyblock id="summit-form" >}}
+SUMMIT FUNDING REQUEST
+======================
+
+1. ORGANIZER
+   Name:
+   Apache ID:
+   Role on project:
+   Email:
+   Co-organizers (if any):
+
+2. EVENT DETAILS
+   Date:
+   Start/end time:
+   Venue (name + address):
+   Venue cost: $
+   Expected attendance:
+   Event page URL (if exists):
+
+3. PROJECT & PROGRAM
+   Apache project:
+   Why does this project need a summit now? (new release, community
+   growth, governance transition, etc.):
+   Draft agenda or program outline:
+   Confirmed speakers/facilitators:
+
+4. BUDGET (detailed)
+   Venue rental: $
+   Catering (breakfast/lunch/breaks, per-person estimate): $
+   AV equipment rental (if needed): $
+   Signage and printed materials: $
+   Speaker expenses (if any): $
+   Other (specify): $
+   TOTAL REQUESTED (max $6,000): $
+
+5. SPONSORSHIP & CO-FUNDING
+   Have you sought corporate sponsors for this event? [Yes/No]:
+   If yes, what did they offer?
+   Is any portion funded by other sources?
+   What happens if ComDev funding is not available? (event cancelled,
+   reduced scope, etc.)
+
+6. PMC APPROVAL (REQUIRED)
+   Link to lists.apache.org thread showing your project PMC has
+   discussed and approved this summit request:
+
+7. EXPECTED OUTCOMES
+   What does success look like for this event?
+   How will you measure it?
+{{< /copyblock >}}
+
+## After the event
+
+Post a detailed report to dev@community.apache.org and submit receipts
+for reimbursement.

--- a/static/js/calendar-DO-NOT-EDIT.json
+++ b/static/js/calendar-DO-NOT-EDIT.json
@@ -1,49 +1,13 @@
 {
  "kind": "calendar#events",
- "etag": "\"p329fjfm9ouq980o\"",
+ "etag": "\"p33vqdvdmp3apa0o\"",
  "summary": "Apache Conferences & Events",
  "description": "",
- "updated": "2026-05-12T20:11:49.921Z",
+ "updated": "2026-07-15T20:54:17.410Z",
  "timeZone": "America/Los_Angeles",
  "accessRole": "reader",
  "defaultReminders": [],
  "items": [
-  {
-   "kind": "calendar#event",
-   "etag": "\"3551530056191518\"",
-   "id": "7db05df3s8c3hi96n4h3gung6j_20260711T080000Z",
-   "status": "confirmed",
-   "htmlLink": "https://www.google.com/calendar/event?eid=N2RiMDVkZjNzOGMzaGk5Nm40aDNndW5nNmpfMjAyNjA3MTFUMDgwMDAwWiBuZXJzZWlnb3Nwc2VzMDY4amQ1N2JrNWFyOEBn",
-   "created": "2025-07-26T09:49:52.000Z",
-   "updated": "2026-04-09T20:03:48.095Z",
-   "summary": "Flink Forward Asia 2026",
-   "description": "\u003ca href=\"https://asia.flink-forward.org/shenzhen-2026\"\u003ehttps://asia.flink-forward.org/shenzhen-2026\u003c/a\u003e",
-   "location": "Shenzhen, Guangdong Province, China",
-   "creator": {
-    "email": "markt@gsuite.cloud.apache.org"
-   },
-   "organizer": {
-    "email": "nerseigospses068jd57bk5ar8@group.calendar.google.com",
-    "displayName": "Apache Conferences & Events",
-    "self": true
-   },
-   "start": {
-    "dateTime": "2026-06-26T01:00:00-07:00",
-    "timeZone": "Europe/London"
-   },
-   "end": {
-    "dateTime": "2026-06-27T09:00:00-07:00",
-    "timeZone": "Europe/London"
-   },
-   "recurringEventId": "7db05df3s8c3hi96n4h3gung6j",
-   "originalStartTime": {
-    "dateTime": "2026-07-11T01:00:00-07:00",
-    "timeZone": "Europe/London"
-   },
-   "iCalUID": "7db05df3s8c3hi96n4h3gung6j@google.com",
-   "sequence": 1,
-   "eventType": "default"
-  },
   {
    "kind": "calendar#event",
    "etag": "\"3540276207877758\"",
@@ -79,12 +43,12 @@
   },
   {
    "kind": "calendar#event",
-   "etag": "\"3556020435674174\"",
+   "etag": "\"3563106265271006\"",
    "id": "6bm2530mld8n8l9237juo52g86_20260922T080000Z",
    "status": "confirmed",
    "htmlLink": "https://www.google.com/calendar/event?eid=NmJtMjUzMG1sZDhuOGw5MjM3anVvNTJnODZfMjAyNjA5MjJUMDgwMDAwWiBuZXJzZWlnb3Nwc2VzMDY4amQ1N2JrNWFyOEBn",
    "created": "2026-05-05T19:43:37.000Z",
-   "updated": "2026-05-05T19:43:37.837Z",
+   "updated": "2026-06-15T19:52:12.635Z",
    "summary": "Fluss Forward London",
    "location": "London, UK",
    "creator": {
@@ -100,7 +64,7 @@
     "timeZone": "Europe/London"
    },
    "end": {
-    "dateTime": "2026-09-22T09:00:00-07:00",
+    "dateTime": "2026-09-23T09:00:00-07:00",
     "timeZone": "Europe/London"
    },
    "recurringEventId": "6bm2530mld8n8l9237juo52g86",
@@ -114,16 +78,18 @@
   },
   {
    "kind": "calendar#event",
-   "etag": "\"3556020435674174\"",
-   "id": "6bm2530mld8n8l9237juo52g86_20260923T080000Z",
+   "etag": "\"3564803870245182\"",
+   "id": "625uqaireusn8q8o3vs5lhl6pr",
    "status": "confirmed",
-   "htmlLink": "https://www.google.com/calendar/event?eid=NmJtMjUzMG1sZDhuOGw5MjM3anVvNTJnODZfMjAyNjA5MjNUMDgwMDAwWiBuZXJzZWlnb3Nwc2VzMDY4amQ1N2JrNWFyOEBn",
-   "created": "2026-05-05T19:43:37.000Z",
-   "updated": "2026-05-05T19:43:37.837Z",
-   "summary": "Fluss Forward London",
-   "location": "London, UK",
+   "htmlLink": "https://www.google.com/calendar/event?eid=NjI1dXFhaXJldXNuOHE4bzN2czVsaGw2cHIgbmVyc2VpZ29zcHNlczA2OGpkNTdiazVhcjhAZw",
+   "created": "2026-06-25T15:38:34.000Z",
+   "updated": "2026-06-25T15:38:55.122Z",
+   "summary": "Lakehouse Day",
+   "description": "\u003ca href=\"https://communityovercode.org/lakehouse-day/\"\u003ehttps://communityovercode.org/lakehouse-day/\u003c/a\u003e",
+   "location": "Glasgow, UK",
    "creator": {
-    "email": "markt@gsuite.cloud.apache.org"
+    "email": "rbowen@rcbowen.com",
+    "displayName": "Rich Bowen"
    },
    "organizer": {
     "email": "nerseigospses068jd57bk5ar8@group.calendar.google.com",
@@ -131,19 +97,13 @@
     "self": true
    },
    "start": {
-    "dateTime": "2026-09-23T01:00:00-07:00",
-    "timeZone": "Europe/London"
+    "date": "2026-10-10"
    },
    "end": {
-    "dateTime": "2026-09-23T09:00:00-07:00",
-    "timeZone": "Europe/London"
+    "date": "2026-10-11"
    },
-   "recurringEventId": "6bm2530mld8n8l9237juo52g86",
-   "originalStartTime": {
-    "dateTime": "2026-09-23T01:00:00-07:00",
-    "timeZone": "Europe/London"
-   },
-   "iCalUID": "6bm2530mld8n8l9237juo52g86@google.com",
+   "transparency": "transparent",
+   "iCalUID": "625uqaireusn8q8o3vs5lhl6pr@google.com",
    "sequence": 0,
    "eventType": "default"
   },


### PR DESCRIPTION
Applicant-facing pages under events/apply/ with copy-paste forms for speaker travel, meetup, sprint, summit, and materials requests. All marked PROPOSED/not yet active. Not linked from any index page.