### PR TITLE
Add Tooling project to hackathon schedule

### DIFF
--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -120,6 +120,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | [StreamPipes](https://streampipes.apache.org/) | [dev@ thread](https://lists.apache.org/thread/yko4ypzx2r3dw1glkwpylc3kqgkhoqhc) |
 | [Superset](https://superset.apache.org/) | [dev@ thread](https://lists.apache.org/thread/f2bs0tfbmfmhl3r3zgf69p27mkfq7n68) |
 | [Tomcat](tomcat.html) | [dev@ thread](https://lists.apache.org/thread/ox1q1wvtzcf6ko3xv2z5m1nz5dnjv6h2) |
+| [Tooling](https://tooling.apache.org) |  |
 | [Wayang](https://wayang.apache.org/) | [dev@ thread](https://lists.apache.org/thread/nstct4k069v748rq622tt5vx2c66objf) |
 
 *Eventually each project will have a dedicated page with hackathon task ideas and contributor guidance.*
@@ -144,7 +145,7 @@ Tuesday, 13 October
 
 | Slot | Project 1 | Project 2 | Project 3 | Project 4 | Project 5 |
 | --- | --- | --- | --- | --- | --- |
-| Early (11:20–15:00) | Arrow |  |  |  |  |
+| Early (11:20–15:00) | Arrow | Tooling |  |  |  |
 | Late (15:00–18:40) | Mahout |  |  |  |  |
 
 Wednesday, 14 October


### PR DESCRIPTION
Want to have space to help projects start to use ATR