### PR TITLE
Add Arrow Hackathon page

### DIFF
--- a/source/events/2026/community-over-code/arrow.md
+++ b/source/events/2026/community-over-code/arrow.md
@@ -43,7 +43,7 @@ We're focusing on:
      channels, contribution guides, dev environment setup docs, etc. -->
 
 * [Contribution guide and dev setup](https://arrow.apache.org/docs/developers/guide/index.html)
-* [Dev mailing list thread about the hackathon](https://lists.apache.org/thread/XXXXX)
+* [Dev mailing list thread about the hackathon](https://lists.apache.org/thread/zc9bkh7o4mmg5lzsfdy5v30fn634hyn0)
 * [GitHub issues](https://github.com/apache/arrow/issues)
 * [Zulip](https://arrow-dev.zulipchat.com/)
 

--- a/source/events/2026/community-over-code/arrow.md
+++ b/source/events/2026/community-over-code/arrow.md
@@ -1,0 +1,65 @@
+---
+title: "Apache Arrow — Hackathon at Community over Code Glasgow 2026"
+---
+
+<img src="/images/apache-oak-leaf.svg" alt="Apache" style="height:1.4em; vertical-align:middle;"> **[Community over Code 2026](https://communityovercode.org) — Glasgow, UK, October 11–14**
+
+**[Register now](https://communityovercode.apache.org/events/glasgow-2026/register)** | [Event website](https://communityovercode.org) | [Hackathon overview](hackathon.html)
+
+## Apache Arrow — Hackathon
+
+<!-- Copy this file to yourproject.md (lowercase, no spaces) and fill
+     in the sections below. Then add a link to your page from the table
+     in hackathon.md. Submit both changes as a single PR. -->
+
+### Coordinator
+
+<!-- Who is the point of contact for your project at the hackathon?
+     This person should be present at the event and available to help
+     participants get started. -->
+
+* **Nic Crane** — thisisnic@apache.org
+* **Matt Topol** — zeroshade@apache.org
+
+### What We're Working On
+
+<!-- Describe the kinds of tasks participants can expect. Be as specific
+     as you like — or link to a curated issue list. Indicate difficulty
+     levels where possible so participants can self-select. -->
+
+We're focusing on:
+
+* **Good first issues** — small, well-scoped tasks suitable for new
+  contributors: [GitHub issues labeled "good first issue"](https://github.com/apache/arrow/issues?q=label%3A%22good+first+issue%22)
+* **Documentation improvements** — help us improve our getting-started
+  guides and API docs
+* **Bug fixes** — a curated set of bugs that are approachable with
+  mentoring support
+
+### Resources
+
+<!-- Link to anything that helps participants prepare or find their way
+     in — issue trackers, mailing list threads, discussion forums, chat
+     channels, contribution guides, dev environment setup docs, etc. -->
+
+* [Contribution guide and dev setup](https://arrow.apache.org/docs/developers/guide/index.html)
+* [Dev mailing list thread about the hackathon](https://lists.apache.org/thread/XXXXX)
+* [GitHub issues](https://github.com/apache/arrow/issues)
+* [Zulip](https://arrow-dev.zulipchat.com/)
+
+### Getting Started Before the Event
+
+<!-- Optional — if there's anything participants should do ahead of
+     time (clone a repo, set up a dev environment, read a doc), mention
+     it here so they can hit the ground running. -->
+
+To make the most of hackathon time, we recommend:
+
+1. Clone the repo and get the build working: [setup instructions](https://arrow.apache.org/docs/developers/index.html)
+2. Browse the issue list and pick one that interests you
+3. Introduce yourself on the dev@ list or chat channel
+
+---
+
+* Back to the [Hackathon overview](hackathon.html)
+* Questions? Join **#hackathon** on [apachecon.slack.com](http://s.apache.org/apachecon-slack)

--- a/source/events/2026/community-over-code/arrow.md
+++ b/source/events/2026/community-over-code/arrow.md
@@ -20,6 +20,7 @@ title: "Apache Arrow — Hackathon at Community over Code Glasgow 2026"
 
 * **Nic Crane** — thisisnic@apache.org
 * **Matt Topol** — zeroshade@apache.org
+* **Alenka Frim** — alenka@apache.org
 
 ### What We're Working On
 
@@ -27,10 +28,17 @@ title: "Apache Arrow — Hackathon at Community over Code Glasgow 2026"
      as you like — or link to a curated issue list. Indicate difficulty
      levels where possible so participants can self-select. -->
 
+There are several areas you can contribute to: Arrow C++ and the PyArrow
+and R bindings built on top of it (all in the apache/arrow repo), and
+Arrow Go (in apache/arrow-go). The Parquet C++ and Go libraries also
+live in these repositories, so you may find yourself contributing to
+Apache Parquet too.
+
 We're focusing on:
 
 * **Good first issues** — small, well-scoped tasks suitable for new
-  contributors: [GitHub issues labeled "good first issue"](https://github.com/apache/arrow/issues?q=label%3A%22good+first+issue%22)
+  contributors: [apache/arrow issues labeled "good first issue"](https://github.com/apache/arrow/issues?q=label%3A%22good+first+issue%22)
+  and [apache/arrow-go issues labeled "good first issue"](https://github.com/apache/arrow-go/issues?q=label%3A%22good+first+issue%22)
 * **Documentation improvements** — help us improve our getting-started
   guides and API docs
 * **Bug fixes** — a curated set of bugs that are approachable with
@@ -44,7 +52,9 @@ We're focusing on:
 
 * [Contribution guide and dev setup](https://arrow.apache.org/docs/developers/guide/index.html)
 * [Dev mailing list thread about the hackathon](https://lists.apache.org/thread/zc9bkh7o4mmg5lzsfdy5v30fn634hyn0)
-* [GitHub issues](https://github.com/apache/arrow/issues)
+* [GitHub issues for apache/arrow](https://github.com/apache/arrow/issues) (C++, PyArrow and more)
+* [GitHub issues for apache/arrow-go](https://github.com/apache/arrow-go/issues)
+* [AI-generated code guidelines](https://arrow.apache.org/docs/developers/overview.html#ai-generated-code) — please read before using AI tools to prepare a contribution
 * [Zulip](https://arrow-dev.zulipchat.com/)
 
 ### Getting Started Before the Event
@@ -55,7 +65,10 @@ We're focusing on:
 
 To make the most of hackathon time, we recommend:
 
-1. Clone the repo and get the build working: [setup instructions](https://arrow.apache.org/docs/developers/index.html)
+1. Clone the repo and get the build working, following either the
+   [C++/PyArrow setup instructions](https://arrow.apache.org/docs/developers/index.html)
+   or the [Arrow Go package docs](https://pkg.go.dev/github.com/apache/arrow-go/v18/),
+   depending on where you want to contribute
 2. Browse the issue list and pick one that interests you
 3. Introduce yourself on the dev@ list or chat channel
 

--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -97,7 +97,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | Task List                                               | Discussion                                                                                                        |
 |---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | [Airflow](https://airflow.apache.org/)                  | [dev@ thread](https://lists.apache.org/thread/c0fnphvb1bs5wbd454x7qclzcqj4wp1o)                                   |
-| [Arrow](https://arrow.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/j63qwqrbosthf1ml3q7yxho89xhx5hoj)                                   |
+| [Arrow](arrow.html)                                     | [dev@ thread](https://lists.apache.org/thread/j63qwqrbosthf1ml3q7yxho89xhx5hoj)                                   |
 | [Camel](https://camel.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/5ws6zdfofxd6typhz7fg1np8j7fn77ho)                                   |
 | [CloudStack](https://cloudstack.apache.org/)            | [dev@ thread](https://lists.apache.org/thread/gnmxsxb39plvp7wcq2tmw76r7jphry8c)                                   |
 | [Fineract](fineract.html)                               | [dev@ thread](https://lists.apache.org/thread/kvp25nx027ypky93rgo2g6ylbf61w5oh)                                   |


### PR DESCRIPTION
Adds a hackathon page for Apache Arrow at Community over Code Glasgow 2026
(`source/events/2026/community-over-code/arrow.md`), following the project
page template.

Also updates the participating projects table in `hackathon.md` so the
Arrow row links to the new page.
