### PR TITLE
Updates for Apache Sourcelume

### DIFF
--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -117,7 +117,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | [Pekko](https://pekko.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/pkgkjq3748blo1g9znvrh556s488sox2)                                   |
 | [SIS](sis.html)                                         | [dev@ thread](https://lists.apache.org/thread/x5pyd9cwjhyc8lpgsgfnvpy8g72l91c9)                                   |
 | Solr                                                    | [dev@ thread](https://lists.apache.org/thread/f8bjyy06c0v2lddol6vvv5n8tzd3y9vl)                                   |
-| [Sourcelume](sourcelume.html)                           | [dev@ thread]                                                                                                     |
+| [Sourcelume](sourcelume.html)                           | [dev@ thread](https://lists.apache.org/thread/yh15s53pb6l21yq28l1sbq6c3qgk584p)                                                                                                   |
 | [Spark](https://spark.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/711z5rcx7pb2wrwm0t41l6ffx21jxyr9)                                   |
 | [StreamPipes](https://streampipes.apache.org/)          | [dev@ thread](https://lists.apache.org/thread/yko4ypzx2r3dw1glkwpylc3kqgkhoqhc)                                   |
 | [Superset](https://superset.apache.org/)                | [dev@ thread](https://lists.apache.org/thread/f2bs0tfbmfmhl3r3zgf69p27mkfq7n68)                                   |

--- a/source/events/2026/community-over-code/sourcelume.md
+++ b/source/events/2026/community-over-code/sourcelume.md
@@ -32,6 +32,9 @@ We're focusing on:
   contributors:
 * **Documentation improvements** — help us improve our getting-started
   guides and API docs
+  * Website Repo: https://github.com/apache/sourcelume-site
+    * Geting started with Pelican https://infra.apache.org/asf-pelican-gettingstarted.html
+    * General Website guidelines https://infra.apache.org/project-site.html
 * **Bug fixes** — a curated set of bugs that are approachable with
   mentoring support
 
@@ -60,8 +63,10 @@ We're focusing on:
 To make the most of hackathon time, we recommend:
 
 1. Clone the repo and get the build working:
+   2. Apache Sourcelume Spec: https://github.com/apache/sourcelume-spec
+   3. Apache Sourcelume Registry: https://github.com/apache/sourcelume-registry
 2. Browse the issue list and pick one that interests you
-3. Introduce yourself on the dev@ list or chat channel
+3. Introduce yourself on the dev@sourcelume.apache.org list or chat channel
 
 ---
 


### PR DESCRIPTION
Added link to Dev thread for Apache Sourcelume Hackathon.
Updated information in the sourcelume.md file to include links to our various repos so that contributors can have our documentation, spec, registry repos cloned ahead of time.