### PR TITLE
Create tooling.md for Apache Tooling hackathon 2026

### DIFF
--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -122,7 +122,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | [StreamPipes](https://streampipes.apache.org/)          | [dev@ thread](https://lists.apache.org/thread/yko4ypzx2r3dw1glkwpylc3kqgkhoqhc)                                   |
 | [Superset](https://superset.apache.org/)                | [dev@ thread](https://lists.apache.org/thread/f2bs0tfbmfmhl3r3zgf69p27mkfq7n68)                                   |
 | [Tomcat](tomcat.html)                                   | [dev@ thread](https://lists.apache.org/thread/ox1q1wvtzcf6ko3xv2z5m1nz5dnjv6h2)                                   |
-| [Tooling](https://tooling.apache.org)                   |                                                                                                                   |
+| [Tooling](tooling.html)                   |                                                                                                                   |
 | [Wayang](https://wayang.apache.org/)                    | [dev@ thread](https://lists.apache.org/thread/nstct4k069v748rq622tt5vx2c66objf)                                   |
 
 *Eventually each project will have a dedicated page with hackathon task ideas and contributor guidance.*

--- a/source/events/2026/community-over-code/tooling.md
+++ b/source/events/2026/community-over-code/tooling.md
@@ -1,0 +1,48 @@
+---
+title: "Apache Tooling — Hackathon at Community over Code Glasgow 2026"
+---
+
+<img src="/images/apache-oak-leaf.svg" alt="Apache" style="height:1.4em; vertical-align:middle;"> **[Community over Code 2026](https://communityovercode.org) — Glasgow, UK, October 11–14**
+
+**[Register now](https://communityovercode.apache.org/events/glasgow-2026/register)** | [Event website](https://communityovercode.org) | [Hackathon overview](hackathon.html)
+
+## Apache Tooling — Hackathon
+
+### Coordinator
+
+<!-- Who is the point of contact for your project at the hackathon?
+     This person should be present at the event and available to help
+     participants get started. -->
+
+* **Alastair McFarlane** — arm@apache.org
+
+### What We're Working On
+
+We're focusing on:
+
+* **Apache Trusted Releases** — we have launched the Beta and want to help your PMCs start to use the system.
+* **Documentation improvements** — help us improve our tutorial and users guide.
+
+### Resources
+
+If you wish to get started with ATR Beta.
+
+* [Releases](https://releases.apache.org)
+* [Release Catalog](https://release-catalog.apache.org)
+
+If you wish to help with documentation then familiarize yourself with the following.
+
+* [Contribution guide](https://github.com/apache/tooling-trusted-releases?tab=contributing-ov-file)
+* [Development setup](https://github.com/apache/tooling-trusted-releases/blob/main/DEVELOPMENT.md)
+* [GitHub issues](https://github.com/apache/tooling-trusted-releases/issues)
+* [Slack channel](https://the-asf.slack.com/archives/C049WADAAQG)
+
+### Who's Planning to Attend
+
+* Alastair McFarlane (ATR Developer)
+* Dave Fisher (Documentation and Architecture)
+
+---
+
+* Back to the [Hackathon overview](hackathon.html)
+* Questions? Join **#hackathon** on [apachecon.slack.com](http://s.apache.org/apachecon-slack)


### PR DESCRIPTION
Added details about the Apache Tooling hackathon at Community over Code 2026, including coordinator information, focus areas, resources, and attendees.