### PR TITLE
Add Apache Doris to the hackathon and claim the Tuesday early slot

### DIFF
--- a/source/events/2026/community-over-code/doris.md
+++ b/source/events/2026/community-over-code/doris.md
@@ -32,7 +32,7 @@ those you find interesting, there is a task here that touches it.
 
 ### What We're Working On
 
-We'll bring tasks in four areas. A curated task list with specific issues
+We'll bring tasks in five areas. A curated task list with specific issues
 will be published on this page closer to the event; in the meantime, the
 directions below should tell you whether there's something here for you.
 
@@ -53,10 +53,19 @@ directions below should tell you whether there's something here for you.
   self-contained, and has a reference implementation elsewhere to compare
   against, which makes it a clean way to learn the build, the test
   harness and the review process in one sitting.
+* **Something built on Doris** *(any language, no engine internals
+  required)* — not a change to Doris itself, but an application that
+  shows what it can do: a hybrid search demo combining BM25 text
+  retrieval with vector similarity over the same table, an agent that
+  uses Doris as its memory, a dashboard over a lakehouse table. Demos
+  are how most people discover a feature exists, so a good one is worth
+  as much to the project as a patch — and this is the option to pick if
+  you'd rather build with Doris than in it.
 
 ### Resources
 
 * [Join Doris Slack](https://doris.apache.org/slack)
+* [Quick start](https://doris.apache.org/docs/gettingStarted/quick-start) — get a Doris running in minutes, no build needed
 * [How to contribute](https://doris.apache.org/community/how-to-contribute/)
 * [Building Doris with Docker](https://doris.apache.org/community/source-install/compilation-with-docker) — the fastest route to a working build
 * [GitHub issues](https://github.com/apache/doris/issues)
@@ -64,20 +73,27 @@ directions below should tell you whether there's something here for you.
 
 ### Getting Started Before the Event
 
-Doris is a large C++ and Java codebase and a first full build takes a
-while, so please don't leave it until the morning of the hackathon:
+What to prepare depends on which direction you pick:
 
-1. **Get a build working ahead of time** using the
+1. **If you plan to change Doris** — get a build working ahead of time
+   using the
    [official development Docker image](https://doris.apache.org/community/source-install/compilation-with-docker).
-   Building inside the image saves you from assembling the third-party
-   dependencies by hand. Start this the day before at the latest.
-2. **Decide roughly which direction interests you** from the four above,
+   Doris is a large C++ and Java codebase, a first full build takes a
+   while, and building inside the image saves you from assembling the
+   third-party dependencies by hand. Start this the day before at the
+   latest, not on the morning of the hackathon.
+2. **If you plan to build something on Doris** — you don't need to
+   compile anything. Follow the
+   [quick start](https://doris.apache.org/docs/gettingStarted/quick-start)
+   to get a cluster running locally, and bring whatever language and
+   client you're comfortable with.
+3. **Decide roughly which direction interests you** from the five above,
    so we can point you at a matching task on the day.
-3. **Say hello** on [Slack](https://doris.apache.org/slack) or the dev@
+4. **Say hello** on [Slack](https://doris.apache.org/slack) or the dev@
    list so we know to look out for you.
 
-If you can't get a build running, come anyway — documentation tasks need
-nothing but a text editor, and we can pair on the build in the room.
+If none of that works out, come anyway — documentation needs nothing but
+a text editor, and we can sort out builds and clusters in the room.
 
 ---
 

--- a/source/events/2026/community-over-code/doris.md
+++ b/source/events/2026/community-over-code/doris.md
@@ -8,11 +8,21 @@ title: "Apache Doris — Hackathon at Community over Code Glasgow 2026"
 
 ## Apache Doris — Hackathon
 
-Apache Doris is a real-time analytical database built around an MPP query
-engine and a columnar storage format. If you're curious about how a modern
-OLAP engine executes a query — vectorized execution, cost-based
-optimization, materialized views — the hackathon is a good way to get your
-hands on the code with someone sitting next to you.
+Apache Doris is an open-source, real-time database for modern analytics
+and AI. It answers sub-second queries under high concurrency at petabyte
+scale; it treats structured, text and vector data as first-class citizens
+in the same engine, so a single SQL statement can combine a filter, a
+BM25 text match and a nearest-neighbour search over embeddings; it
+queries Iceberg, Delta Lake and Hudi tables in place, with no copy, which
+makes it an acceleration layer over an open lakehouse rather than yet
+another silo; and increasingly it serves as the store agents run
+on — columnar JSON for tool-call traces, BM25 retrieval for RAG and agent
+memory, MCP for access.
+
+That range is the reason Doris is an interesting codebase to spend an
+afternoon in. Query execution, index structures, storage formats,
+connectors and SQL semantics all live in one repository, so whichever of
+those you find interesting, there is a task here that touches it.
 
 **Session:** Tuesday 13 October, Early slot (11:20–15:00), Wee Dram Room
 
@@ -22,32 +32,34 @@ hands on the code with someone sitting next to you.
 
 ### What We're Working On
 
-Tasks are grouped by how much Doris background they need, so you can pick
-one that matches where you are:
+We'll bring tasks in four areas. A curated task list with specific issues
+will be published on this page closer to the event; in the meantime, the
+directions below should tell you whether there's something here for you.
 
-* **Implement a SQL function** *(easiest first PR — no prior Doris
-  knowledge needed)* — we're working through the functions that MySQL,
-  PostgreSQL, Trino, Hive and ClickHouse have and Doris doesn't. Each one
-  is small, self-contained, and comes with a clear reference
-  implementation to compare against. Pick an unchecked box from
-  [issue #48203](https://github.com/apache/doris/issues/48203).
-* **Documentation** *(no C++ or Java required)* — the
-  [doris-website repository](https://github.com/apache/doris-website/issues)
-  tracks documentation gaps, broken examples, and pages that need a
-  rewrite. Good if you'd rather read and write than compile.
-* **Good first issues** — [issues labeled "good first
-  issue"](https://github.com/apache/doris/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22)
-  in the main repository.
-* **Bug fixes with mentoring** *(some C++ or Java helps)* — we'll bring a
-  curated set of open bugs that are approachable in an afternoon, and
-  we'll walk you through the part of the codebase each one lives in.
+* **Multi-modal lakehouse support** *(the deepest end — some C++ or Java
+  expected)* — extending what Doris can read and push down across open
+  table formats, and broadening the range of data types it handles
+  natively. Good if you want to work on connectors, scan layers or type
+  systems.
+* **Documentation** *(no C++ or Java required)* — filling gaps, fixing
+  examples that no longer match the current release, and making the
+  getting-started path shorter. The most useful thing a newcomer can do,
+  because you still remember which parts were confusing.
+* **Visualization and tooling** *(front-end friendly)* — improving the
+  web UI and the tooling people use to observe and operate a Doris
+  cluster. A good fit if you'd rather write TypeScript than C++.
+* **New SQL functions** *(the easiest first PR)* — implementing functions
+  that other engines have and Doris doesn't. Each one is small,
+  self-contained, and has a reference implementation elsewhere to compare
+  against, which makes it a clean way to learn the build, the test
+  harness and the review process in one sitting.
 
 ### Resources
 
+* [Join Doris Slack](https://doris.apache.org/slack)
 * [How to contribute](https://doris.apache.org/community/how-to-contribute/)
 * [Building Doris with Docker](https://doris.apache.org/community/source-install/compilation-with-docker) — the fastest route to a working build
 * [GitHub issues](https://github.com/apache/doris/issues)
-* [Doris Slack](https://doris.apache.org/slack)
 * [Subscribe to the mailing lists](https://doris.apache.org/community/subscribe-mail-list)
 
 ### Getting Started Before the Event
@@ -59,8 +71,8 @@ while, so please don't leave it until the morning of the hackathon:
    [official development Docker image](https://doris.apache.org/community/source-install/compilation-with-docker).
    Building inside the image saves you from assembling the third-party
    dependencies by hand. Start this the day before at the latest.
-2. **Pick a task** from the lists above and comment on the issue so nobody
-   duplicates your work.
+2. **Decide roughly which direction interests you** from the four above,
+   so we can point you at a matching task on the day.
 3. **Say hello** on [Slack](https://doris.apache.org/slack) or the dev@
    list so we know to look out for you.
 

--- a/source/events/2026/community-over-code/doris.md
+++ b/source/events/2026/community-over-code/doris.md
@@ -1,0 +1,73 @@
+---
+title: "Apache Doris — Hackathon at Community over Code Glasgow 2026"
+---
+
+<img src="/images/apache-oak-leaf.svg" alt="Apache" style="height:1.4em; vertical-align:middle;"> **[Community over Code 2026](https://communityovercode.org) — Glasgow, UK, October 11–14**
+
+**[Register now](https://communityovercode.apache.org/events/glasgow-2026/register)** | [Event website](https://communityovercode.org) | [Hackathon overview](hackathon.html)
+
+## Apache Doris — Hackathon
+
+Apache Doris is a real-time analytical database built around an MPP query
+engine and a columnar storage format. If you're curious about how a modern
+OLAP engine executes a query — vectorized execution, cost-based
+optimization, materialized views — the hackathon is a good way to get your
+hands on the code with someone sitting next to you.
+
+**Session:** Tuesday 13 October, Early slot (11:20–15:00), Wee Dram Room
+
+### Coordinator
+
+* **Mingyu Chen** — morningman@apache.org
+
+### What We're Working On
+
+Tasks are grouped by how much Doris background they need, so you can pick
+one that matches where you are:
+
+* **Implement a SQL function** *(easiest first PR — no prior Doris
+  knowledge needed)* — we're working through the functions that MySQL,
+  PostgreSQL, Trino, Hive and ClickHouse have and Doris doesn't. Each one
+  is small, self-contained, and comes with a clear reference
+  implementation to compare against. Pick an unchecked box from
+  [issue #48203](https://github.com/apache/doris/issues/48203).
+* **Documentation** *(no C++ or Java required)* — the
+  [doris-website repository](https://github.com/apache/doris-website/issues)
+  tracks documentation gaps, broken examples, and pages that need a
+  rewrite. Good if you'd rather read and write than compile.
+* **Good first issues** — [issues labeled "good first
+  issue"](https://github.com/apache/doris/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22)
+  in the main repository.
+* **Bug fixes with mentoring** *(some C++ or Java helps)* — we'll bring a
+  curated set of open bugs that are approachable in an afternoon, and
+  we'll walk you through the part of the codebase each one lives in.
+
+### Resources
+
+* [How to contribute](https://doris.apache.org/community/how-to-contribute/)
+* [Building Doris with Docker](https://doris.apache.org/community/source-install/compilation-with-docker) — the fastest route to a working build
+* [GitHub issues](https://github.com/apache/doris/issues)
+* [Doris Slack](https://doris.apache.org/slack)
+* [Subscribe to the mailing lists](https://doris.apache.org/community/subscribe-mail-list)
+
+### Getting Started Before the Event
+
+Doris is a large C++ and Java codebase and a first full build takes a
+while, so please don't leave it until the morning of the hackathon:
+
+1. **Get a build working ahead of time** using the
+   [official development Docker image](https://doris.apache.org/community/source-install/compilation-with-docker).
+   Building inside the image saves you from assembling the third-party
+   dependencies by hand. Start this the day before at the latest.
+2. **Pick a task** from the lists above and comment on the issue so nobody
+   duplicates your work.
+3. **Say hello** on [Slack](https://doris.apache.org/slack) or the dev@
+   list so we know to look out for you.
+
+If you can't get a build running, come anyway — documentation tasks need
+nothing but a text editor, and we can pair on the build in the room.
+
+---
+
+* Back to the [Hackathon overview](hackathon.html)
+* Questions? Join **#hackathon** on [apachecon.slack.com](http://s.apache.org/apachecon-slack)

--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -100,6 +100,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | [Arrow](arrow.html)                                     | [dev@ thread](https://lists.apache.org/thread/j63qwqrbosthf1ml3q7yxho89xhx5hoj)                                   |
 | [Camel](https://camel.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/5ws6zdfofxd6typhz7fg1np8j7fn77ho)                                   |
 | [CloudStack](https://cloudstack.apache.org/)            | [dev@ thread](https://lists.apache.org/thread/gnmxsxb39plvp7wcq2tmw76r7jphry8c)                                   |
+| [Doris](doris.html)                                     |                                                                                                                   |
 | [Fineract](fineract.html)                               | [dev@ thread](https://lists.apache.org/thread/kvp25nx027ypky93rgo2g6ylbf61w5oh)                                   |
 | [Flink](flink.html)                                     | [dev@ thread](https://lists.apache.org/thread/3412lc0x5vgfbm8phg50q8qlvlsj616p)                                   |
 | [Fluss](fluss.html)                                     | [dev@ thread](https://lists.apache.org/thread/kh2fosjfd11bwprdph684zy0793sqxts)                                   |
@@ -147,7 +148,7 @@ Tuesday, 13 October
 
 | Slot | Project 1 | Project 2 | Project 3 | Project 4 | Project 5 |
 | --- | --- | --- | --- | --- | --- |
-| Early (11:20–15:00) | Arrow | Tooling | Gluten | Magpie |  |
+| Early (11:20–15:00) | Arrow | Tooling | Gluten | Magpie | [Doris](doris.html) |
 | Late (15:00–18:40) | Mahout | Groovy and Grails | Magpie |  |  |
 
 Wednesday, 14 October


### PR DESCRIPTION
Apache Doris would like to take part in the hackathon at Community over Code Glasgow 2026.

This adds:

- `doris.md` — a project hackathon page with the coordinator, the directions we will bring tasks in, and what to prepare beforehand
- Doris in the participating projects table
- Doris in the remaining Project 5 cell of the **Tuesday 13 October, early (11:20–15:00)** slot — one slot only, per the note on the page

**Coordinator:** Mingyu Chen (morningman@apache.org), attending in Glasgow.

The Discussion cell is intentionally empty for now — the dev@ announcement goes out shortly and I will add the thread link in a follow-up commit on this branch. Happy to hold the merge until then if you would rather the table landed complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
