### PR TITLE
Claim Monday early hackathon slot for Spark

### DIFF
--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -140,7 +140,7 @@ Monday, 12 October
 
 | Slot | Project 1 | Project 2  | Project 3 | Project 4 | Project 5 |
 | --- | --- |------------|----------| --- | --- |
-| Early (11:20–15:00) | Solr | Sourcelume | Fineract | Airflow  |  |
+| Early (11:20–15:00) | Solr | Sourcelume | Fineract | Airflow  | Spark |
 | Security (15:10–15:50) | *Security* | *Security* | *Security* | *Security* | *Security* |
 | Late (16:00–18:40) | Solr | Responsible AI |          |  |  |
 


### PR DESCRIPTION
Claiming the remaining Monday early (11:20–15:00) slot for Apache Spark, per the dev@ thread: https://lists.apache.org/thread/711z5rcx7pb2wrwm0t41l6ffx21jxyr9

Made with [Cursor](https://cursor.com)