### PR TITLE
Link the Doris dev@ thread from the hackathon table

### DIFF
--- a/source/events/2026/community-over-code/hackathon.md
+++ b/source/events/2026/community-over-code/hackathon.md
@@ -100,7 +100,7 @@ The following Apache projects have confirmed participation. Follow the thread li
 | [Arrow](arrow.html)                                     | [dev@ thread](https://lists.apache.org/thread/j63qwqrbosthf1ml3q7yxho89xhx5hoj)                                   |
 | [Camel](https://camel.apache.org/)                      | [dev@ thread](https://lists.apache.org/thread/5ws6zdfofxd6typhz7fg1np8j7fn77ho)                                   |
 | [CloudStack](https://cloudstack.apache.org/)            | [dev@ thread](https://lists.apache.org/thread/gnmxsxb39plvp7wcq2tmw76r7jphry8c)                                   |
-| [Doris](doris.html)                                     |                                                                                                                   |
+| [Doris](doris.html)                                     | [dev@ thread](https://lists.apache.org/thread/rdd858b9vmhmqqv5sxzf26qrgf8m2kbs)                                   |
 | [Fineract](fineract.html)                               | [dev@ thread](https://lists.apache.org/thread/kvp25nx027ypky93rgo2g6ylbf61w5oh)                                   |
 | [Flink](flink.html)                                     | [dev@ thread](https://lists.apache.org/thread/3412lc0x5vgfbm8phg50q8qlvlsj616p)                                   |
 | [Fluss](fluss.html)                                     | [dev@ thread](https://lists.apache.org/thread/kh2fosjfd11bwprdph684zy0793sqxts)                                   |


### PR DESCRIPTION
The Doris announcement has gone out to dev@, so this fills in the Discussion cell that #60 deliberately left empty.

Thread: https://lists.apache.org/thread/rdd858b9vmhmqqv5sxzf26qrgf8m2kbs
