### PR TITLE
Use ubuntu-slim runner for the calendar workflow

### DIFF
--- a/.github/workflows/getcalendar.yml
+++ b/.github/workflows/getcalendar.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fetch-calendar:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Switches the `fetch-calendar` job from `ubuntu-latest` to `ubuntu-slim`.

The job only needs bash, curl, git and the Node runtime for actions/checkout@v4 — none of the preinstalled toolchains the slim image drops — so the smaller runner image is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiacQ5MSzv4x9oLPeZvYDL