### PR TITLE
Add grouped Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # The GitHub Actions used by the workflows are this repository's only
+  # tracked dependencies; there are no language package manifests here.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Let a new release sit for a week before proposing it, so a compromised
+    # release has time to be caught and pulled.
+    cooldown:
+      default-days: 7
+    # A single grouped pull request per week instead of one PR per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering the `github-actions` ecosystem — the only tracked dependencies in this repository, since there are no language package manifests here.

* Weekly, grouped into a single pull request rather than one per action.
* Seven day cooldown, so a freshly published release has time to be caught and pulled before Dependabot proposes it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiacQ5MSzv4x9oLPeZvYDL