### PR TITLE
Add zizmor workflow security analysis

### DIFF
--- a/.github/workflows/getcalendar.yml
+++ b/.github/workflows/getcalendar.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-    - uses: actions/checkout@v4
+    # The credentials persisted by the checkout are what the step below uses
+    # to push the refreshed calendar data back to the branch.
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Curl calendar
       run: |
         git config user.email "dev@community.apache.org"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: Zizmor GitHub Actions analysis
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-slim
+
+    steps:
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+    - name: Run zizmor
+      # Findings are reported as annotations on the offending workflow lines
+      # and fail the job.
+      run: uvx zizmor@latest --format=github .
+      env: # for zizmor's online audits
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# zizmor configuration
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  artipacked:
+    ignore:
+      # The calendar refresh deliberately reuses the credentials persisted by
+      # actions/checkout to push the updated data back to the branch.
+      - getcalendar.yml


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh/) as a CI check over `.github/`, so
GitHub Actions security problems (script injection, unpinned actions,
over-broad permissions, credential persistence) get caught in review
rather than after the fact.

### What's here

- **`.github/workflows/zizmor.yml`** — runs `uvx zizmor@latest` over the
  repo on pushes to `main` that touch `.github/`, on PRs that touch
  `.github/`, and on `workflow_dispatch`. Findings are reported as
  annotations on the offending workflow lines and fail the job.
  The workflow itself is clean: `contents: read` only,
  `persist-credentials: false`, and both actions pinned to commit SHAs.

- **`.github/zizmor.yml`** — config waiving the one finding that is
  intentional: `artipacked` on `getcalendar.yml`, which deliberately
  reuses the credentials persisted by `actions/checkout` to push the
  refreshed calendar data back to the branch.

- **`.github/workflows/getcalendar.yml`** — pins `actions/checkout` to a
  commit SHA (v4.4.0) and comments why the persisted credentials are
  needed there.

Dependabot (added in #70) will keep the pinned SHAs current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtqKBTSR2jQF7xhHMBpdoy
